### PR TITLE
fix matrix_rank input shape

### DIFF
--- a/framework/e2e/api_benchmark_new/debug_case/matrix_rank_0.py
+++ b/framework/e2e/api_benchmark_new/debug_case/matrix_rank_0.py
@@ -44,7 +44,7 @@ def _randtool(dtype, low, high, shape):
 
 
 api = "paddle.linalg.matrix_rank"
-all_data = {"x": {"random": True, "type": "Tensor", "dtype": "float32", "shape": [1, 1, 1], "range": [-1, 1]}}
+all_data = {"x": {"random": True, "type": "Tensor", "dtype": "float32", "shape": [10, 10, 10], "range": [-1, 1]}}
 params = {"hermitian": False}
 
 inputs = {}


### PR DESCRIPTION
在现有的api benchmark的测试中，matrix_rank的输入数据的尺寸比较小，导致非计算部分变成运行时候的瓶颈，测试出来的结果不准备，本PR增大的测试数据的尺寸